### PR TITLE
Give subModes a modeName that can be used during bootup/debugging

### DIFF
--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -190,6 +190,7 @@ void changeOmxMode(OMXMode newOmxmode)
 	}
 
 	activeOmxMode->onModeActivated();
+	Serial.println((String)"* Mode changed to: " + *(activeOmxMode->modeName )+  " *");
 }
 
 // ####### END LEDS

--- a/OMX-27-firmware/src/modes/omx_mode_chords.h
+++ b/OMX-27-firmware/src/modes/omx_mode_chords.h
@@ -191,6 +191,8 @@ public:
 	OmxModeChords();
 	~OmxModeChords() {}
 
+	const String modeName = "Chords";
+
 	void InitSetup() override;
 
 	void onModeActivated() override;

--- a/OMX-27-firmware/src/modes/omx_mode_euclidean.h
+++ b/OMX-27-firmware/src/modes/omx_mode_euclidean.h
@@ -21,6 +21,8 @@ public:
 	OmxModeEuclidean();
 	~OmxModeEuclidean() {}
 
+	const String modeName = "Euclidean";
+
 	void InitSetup() override;
 
 	void onModeActivated() override;

--- a/OMX-27-firmware/src/modes/omx_mode_grids.h
+++ b/OMX-27-firmware/src/modes/omx_mode_grids.h
@@ -14,6 +14,8 @@ public:
 	OmxModeGrids();
 	~OmxModeGrids() {}
 
+	const String modeName = "Grids";
+
 	void InitSetup() override;
 
 	void onModeActivated() override;

--- a/OMX-27-firmware/src/modes/omx_mode_interface.h
+++ b/OMX-27-firmware/src/modes/omx_mode_interface.h
@@ -1,12 +1,17 @@
 #pragma once
+#include <string>
 #include "../ClearUI/ClearUI_Input.h"
 #include "../hardware/omx_keypad.h"
 #include "../config.h"
 class OmxModeInterface
 {
+
 public:
+
 	OmxModeInterface() {}
 	virtual ~OmxModeInterface() {}
+
+	const String *modeName;
 
 	virtual void InitSetup() {} // Called once when mode is created
 

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "omx_mode_interface.h"
 #include "../utils/music_scales.h"
 #include "../utils/param_manager.h"
@@ -12,9 +13,12 @@
 
 class OmxModeMidiKeyboard : public OmxModeInterface
 {
+
 public:
 	OmxModeMidiKeyboard();
 	~OmxModeMidiKeyboard() {}
+
+	const String modeName = "MIDI Keyboard";
 
 	void InitSetup() override;
 	void onModeActivated() override;

--- a/OMX-27-firmware/src/modes/omx_mode_sequencer.h
+++ b/OMX-27-firmware/src/modes/omx_mode_sequencer.h
@@ -9,6 +9,8 @@ public:
 	OmxModeSequencer();
 	~OmxModeSequencer() {}
 
+	const String modeName = "Sequencer";
+
 	void InitSetup() override;
 
 	void initPatterns(); // Initializes all patterns

--- a/OMX-27-firmware/src/modes/omx_screensaver.h
+++ b/OMX-27-firmware/src/modes/omx_screensaver.h
@@ -8,6 +8,8 @@ public:
 	OmxScreensaver() {}
 	~OmxScreensaver() {}
 
+	const String modeName = "Screensaver";
+
 	void onPotChanged(int potIndex, int prevValue, int newValue, int analogDelta) override;
 
 	void updateLEDs() override;

--- a/OMX-27-firmware/src/modes/submodes/submode_interface.h
+++ b/OMX-27-firmware/src/modes/submodes/submode_interface.h
@@ -10,6 +10,8 @@ public:
 	SubmodeInterface() {}
 	virtual ~SubmodeInterface() {}
 
+	const String *modeName; // name of the omxMode
+
 	virtual void onModeChanged(){};
 
 	virtual void setEnabled(bool newEnabled);

--- a/OMX-27-firmware/src/modes/submodes/submode_midifxgroup.h
+++ b/OMX-27-firmware/src/modes/submodes/submode_midifxgroup.h
@@ -16,6 +16,8 @@ public:
 	SubModeMidiFxGroup();
 	~SubModeMidiFxGroup() {}
 
+	const String modeName = "Midi FX Group";
+
 	// Interface methods
 	void onModeChanged() override;
 	void onClockTick() override;

--- a/OMX-27-firmware/src/modes/submodes/submode_potconfig.h
+++ b/OMX-27-firmware/src/modes/submodes/submode_potconfig.h
@@ -10,6 +10,8 @@ public:
 	SubModePotConfig();
 	~SubModePotConfig() {}
 
+	const String modeName = "Pot Config";
+
 	// Interface methods
 	void loopUpdate() override;
 	bool updateLEDs() override;


### PR DESCRIPTION
This simply allows a readable modeName value that can be easily printed in the Serial output during the bootstrap process, or whenever a mode is called